### PR TITLE
Add input option "arguments" to pass cli options to the k3s server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is helpful for testing applications /  operators on top of kubernetes clust
 ## Inputs
 * version of k3s  
 > refer to table at the end of this README
+* egress-fix whether to disable the k3s egress selector (bug on v1.22)
 * ports
 
 ## Outputs
@@ -17,6 +18,7 @@ This is helpful for testing applications /  operators on top of kubernetes clust
   id: k3s
   with:
     version: 'latest'
+    egress-fix: false
 - run: |
     kubectl get nodes
     kubectl get pods -A

--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ branding:
   icon: box
   color: green
 runs:
-  using: node12
+  using: node16
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,8 @@ inputs:
   version:  
     description: Version of k3s
     required: true
-  egress-fix:
-    description: Disable the k3s egress selector
+  arguments:
+    description: Arguments for k3s
     required: false
   ports:
     description: Comma delimited list of host_port:container_port values (example "80:80,8080:8080")

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   egress-fix:
     description: Disable the k3s egress selector
-    required: true
+    required: false
   ports:
     description: Comma delimited list of host_port:container_port values (example "80:80,8080:8080")
     required: false

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   version:  
     description: Version of k3s
     required: true
+  egress-fix:
+    description: Disable the k3s egress selector
+    required: true
   ports:
     description: Comma delimited list of host_port:container_port values (example "80:80,8080:8080")
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -2993,6 +2993,7 @@ async function run() {
   try {
     const version = core.getInput('version');
     const ports = core.getInput('ports');
+    const egress_fix = core.getInput('egress-fix');
     const nodeName = 'primary-node'
 
     const kubeconfigPath=`/tmp/output/kubeconfig-${version}.yaml`;
@@ -3005,6 +3006,8 @@ async function run() {
       }
     }
 
+    const egress_options = egress_fix ? "--egress-selector-mode none" : "";
+
     await exec.exec('docker', ["run","-d","--privileged",`--name=k3s-${version}`,
       "-e",`K3S_KUBECONFIG_OUTPUT=${kubeconfigPath}`,
       "-e","K3S_KUBECONFIG_MODE=666",
@@ -3012,7 +3015,7 @@ async function run() {
       "-v","/tmp/output:/tmp/output",
       "-p6443:6443",
       ...portPairs,
-      `rancher/k3s:${version}`,"server"]);
+      `rancher/k3s:${version}`,"server", `${egress_options}`]);
 
     core.exportVariable('KUBECONFIG', kubeconfigPath);
     core.setOutput("kubeconfig", kubeconfigPath);

--- a/dist/index.js
+++ b/dist/index.js
@@ -3006,7 +3006,7 @@ async function run() {
       }
     }
 
-    const egress_options = egress_fix ? "--egress-selector-mode none" : "";
+    const egress_options = egress_fix ? "--egress-selector-mode disabled" : "";
 
     await exec.exec('docker', ["run","-d","--privileged",`--name=k3s-${version}`,
       "-e",`K3S_KUBECONFIG_OUTPUT=${kubeconfigPath}`,

--- a/dist/index.js
+++ b/dist/index.js
@@ -2993,7 +2993,7 @@ async function run() {
   try {
     const version = core.getInput('version');
     const ports = core.getInput('ports');
-    const egress_fix = core.getInput('egress-fix');
+    const extra_args = core.getInput('arguments');
     const nodeName = 'primary-node'
 
     const kubeconfigPath=`/tmp/output/kubeconfig-${version}.yaml`;
@@ -3006,7 +3006,12 @@ async function run() {
       }
     }
 
-    const egress_options = egress_fix ? "--egress-selector-mode disabled" : "";
+    const extra_opts = [];
+    for (const token of extra_args.split(' ')) {
+      if (token) {
+        extra_opts.push(token)
+      }
+    }
 
     await exec.exec('docker', ["run","-d","--privileged",`--name=k3s-${version}`,
       "-e",`K3S_KUBECONFIG_OUTPUT=${kubeconfigPath}`,
@@ -3015,7 +3020,7 @@ async function run() {
       "-v","/tmp/output:/tmp/output",
       "-p6443:6443",
       ...portPairs,
-      `rancher/k3s:${version}`,"server", `${egress_options}`]);
+      `rancher/k3s:${version}`,"server", ...extra_opts]);
 
     core.exportVariable('KUBECONFIG', kubeconfigPath);
     core.setOutput("kubeconfig", kubeconfigPath);

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ async function run() {
   try {
     const version = core.getInput('version');
     const ports = core.getInput('ports');
+    const egress_fix = core.getInput('egress-fix');
     const nodeName = 'primary-node'
 
     const kubeconfigPath=`/tmp/output/kubeconfig-${version}.yaml`;
@@ -19,6 +20,8 @@ async function run() {
       }
     }
 
+    const egress_options = egress_fix ? "--egress-selector-mode none" : "";
+
     await exec.exec('docker', ["run","-d","--privileged",`--name=k3s-${version}`,
       "-e",`K3S_KUBECONFIG_OUTPUT=${kubeconfigPath}`,
       "-e","K3S_KUBECONFIG_MODE=666",
@@ -26,7 +29,7 @@ async function run() {
       "-v","/tmp/output:/tmp/output",
       "-p6443:6443",
       ...portPairs,
-      `rancher/k3s:${version}`,"server"]);
+      `rancher/k3s:${version}`,"server", `${egress_options}`]);
 
     core.exportVariable('KUBECONFIG', kubeconfigPath);
     core.setOutput("kubeconfig", kubeconfigPath);

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ async function run() {
       }
     }
 
-    const egress_options = egress_fix ? "--egress-selector-mode none" : "";
+    const egress_options = egress_fix ? "--egress-selector-mode disabled" : "";
 
     await exec.exec('docker', ["run","-d","--privileged",`--name=k3s-${version}`,
       "-e",`K3S_KUBECONFIG_OUTPUT=${kubeconfigPath}`,


### PR DESCRIPTION
Add the input option `arguments` to the k3s action that can be used to pass extra options to the k3s server on startup.

This is needed due to a bug in the k3s v1.22 branch where the web sockets connections between nodes aren't managed properly. This is used to pass the "--egress-selector-mode disabled" option to v1.22 of k3s. See [this kots PR](https://github.com/replicatedhq/kots/pull/3572) that has more details.

I tested this by creating a throw-away commit on the PR that instigated this change, the full run can be seen in [this action](https://github.com/replicatedhq/kots/actions/runs/4018766739/jobs/6905008056), for example, [this job](https://github.com/replicatedhq/kots/actions/runs/4019016256/jobs/6905523939) shows using passed in arguments and [this job](https://github.com/replicatedhq/kots/actions/runs/4019016256/jobs/6905523841) shows no passed in arguments (expand the "Run replicated/action-k3s" log entry and look at the docker command that runs k3s at the top).

Part of issue [SC-67356](https://app.shortcut.com/replicated/story/67356/kots-cli-port-forwarding-fails-intermittently)